### PR TITLE
Support youtube-nocookie.com

### DIFF
--- a/youtube-video-time-saver.user.js
+++ b/youtube-video-time-saver.user.js
@@ -7,6 +7,7 @@
 // @updateURL           https://raw.githubusercontent.com/Robbendebiene/Youtube-Video-Time-Saver/master/youtube-video-time-saver.user.js
 // @icon                https://www.youtube.com/favicon.ico
 // @match               *://www.youtube.com/*
+// @match               *://www.youtube-nocookie.com/*
 // @run-at              document-end
 // ==/UserScript==
 


### PR DESCRIPTION
Support youtube-nocookie.com

Add support for URLs using "youtube-nocookie.com" instead of just
"youtube.com".

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>